### PR TITLE
Import fix

### DIFF
--- a/django_mri/signals.py
+++ b/django_mri/signals.py
@@ -17,7 +17,7 @@ from django.dispatch import receiver
 from django_dicom.models.series import Series
 from django_mri.models.scan import Scan
 from django_mri.models.session import Session
-from django_mri.utils import get_subject_model, get_session
+from django_mri.utils import get_subject_model, get_session_by_series
 
 _SCAN_FROM_SERIES_FAILURE = (
     "Failed to create Scan instance for DICOM series {series_id}!\n{exception}"
@@ -71,8 +71,8 @@ def series_post_save_receiver(
         Whether the series instance was created or not
     """
 
+    session = get_session_by_series(instance)
     try:
-        session = get_session(instance)
         Scan.objects.get_or_create(dicom=instance, session=session)
     except Exception as exception:
         message = _SCAN_FROM_SERIES_FAILURE.format(

--- a/django_mri/utils/__init__.py
+++ b/django_mri/utils/__init__.py
@@ -7,5 +7,5 @@ from django_mri.utils.utils import (
     get_subject_model,
     get_group_model,
     get_mri_root,
-    get_session,
+    get_session_by_series,
 )

--- a/django_mri/utils/utils.py
+++ b/django_mri/utils/utils.py
@@ -74,29 +74,45 @@ def get_dicom_root() -> Path:
 
 def get_session_by_series(series):
     """
-    Returns the appropriate session to the current series.
+    Returns the appropriate session for the given
+    :class:`~django_dicom.models.series.Series` instance.
+
+    Parameters
+    ----------
+    series : :class:`~django_dicom.models.series.Series`
+        DICOM series to infer the session from
+
+    Returns
+    -------
+    :class:`~django_mri.models.session.Session`
+        The appropriate session
     """
 
     Session = apps.get_model("django_mri", "Session")
     Subject = get_subject_model()
 
-    header = series.image_set.first().header.instance
-    study_date, study_time = header.get("StudyDate"), header.get("StudyTime")
-    session_time = datetime.combine(study_date, study_time).replace(
-        tzinfo=pytz.UTC
-    )
-    try:
-        subject = Subject.objects.get(id_number=series.patient.uid)
-    # If the subject doesn't exist in the database, create a new session
-    # without an associated subject.
-    except ObjectDoesNotExist:
-        session = Session.objects.create(time=session_time)
-    # If the subject does exist, look for an existing session by time.
-    else:
-        session = subject.mri_session_set.filter(time=session_time).first()
-        # If no existing session exists, create one.
-        if not session:
-            session = Session.objects.create(
-                time=session_time, subject=subject
-            )
-    return session
+    image = series.image_set.first()
+    if image:
+        header = image.header.instance
+        study_date, study_time = (
+            header.get("StudyDate"),
+            header.get("StudyTime"),
+        )
+        session_time = datetime.combine(study_date, study_time).replace(
+            tzinfo=pytz.UTC
+        )
+        try:
+            subject = Subject.objects.get(id_number=series.patient.uid)
+        # If the subject doesn't exist in the database, create a new session
+        # without an associated subject.
+        except ObjectDoesNotExist:
+            session = Session.objects.create(time=session_time)
+        # If the subject does exist, look for an existing session by time.
+        else:
+            session = subject.mri_session_set.filter(time=session_time).first()
+            # If no existing session exists, create one.
+            if not session:
+                session = Session.objects.create(
+                    time=session_time, subject=subject
+                )
+        return session


### PR DESCRIPTION
Changed `get_session()` to `get_session_by_series()` and made it simply return `None` if no images are associated with the provided series. To compensate for not creating the session in the premature invocation, I added an additional `save()` call to invoke the signal again after the image is saved. Resolved #46.