### PR TITLE
Prevent NIfTI generation in AnatomicalPreprocessing progress querying

### DIFF
--- a/django_mri/analysis/automation/anatomical/preprocessing.py
+++ b/django_mri/analysis/automation/anatomical/preprocessing.py
@@ -104,5 +104,7 @@ class AnatomicalPreprocessing(QuerySetRunner):
         bool
             Whether the provided scan has an existing run or not
         """
-        value = self.get_instance_representation(instance)
-        return instance._nifti and self.input_set.filter(value=value)
+        if instance._nifti:
+            value = self.get_instance_representation(instance)
+            return bool(self.input_set.filter(value=value))
+        return False

--- a/django_mri/analysis/automation/anatomical/preprocessing.py
+++ b/django_mri/analysis/automation/anatomical/preprocessing.py
@@ -106,5 +106,5 @@ class AnatomicalPreprocessing(QuerySetRunner):
         """
         if instance._nifti:
             value = self.get_instance_representation(instance)
-            return bool(self.input_set.filter(value=value))
+            return self.input_set.filter(value=value).exists()
         return False


### PR DESCRIPTION
Fixed has_run() to prevent NIfTI generation when querying progress. Resolves #77.